### PR TITLE
fix(loginserver): harden pre-auth binary packet length parsing

### DIFF
--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/GameServerThread.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/GameServerThread.java
@@ -10,7 +10,7 @@ import java.net.UnknownHostException;
 import java.security.KeyPair;
 import java.security.interfaces.RSAPrivateKey;
 import java.security.interfaces.RSAPublicKey;
-import java.sql.SQLException; // Added this line
+import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -64,7 +64,7 @@ public class GameServerThread extends Thread
 	// Informações sobre o Game Server conectado.
 	private GameServerInfo _gsi;
 	
-		public GameServerThread(Socket con) throws IOException
+	public GameServerThread(Socket con) throws IOException
 	{
 		_connection = con;
 		_connectionIp = con.getInetAddress().getHostAddress();
@@ -94,7 +94,7 @@ public class GameServerThread extends Thread
 			return;
 		}
 		
-try
+		try
 		{
 			// Envia o pacote de inicialização com a chave pública RSA.
 			sendPacket(new InitLS(_publicKey.getModulus().toByteArray()));
@@ -171,11 +171,15 @@ try
 						onReceiveServerStatus(data);
 						break;
 					
-default:
+					default:
 						LOGGER.warn("Opcode desconhecido ({}) do gameserver, fechando conexão.", Integer.toHexString(packetType).toUpperCase());
 						forceClose(LoginServerFail.NOT_AUTHED);
 				}
 			}
+		}
+		catch (IllegalArgumentException e)
+		{
+			LOGGER.warn("Pacote malformado recebido do gameserver {}. Fechando conexão: {}", _connectionIp, e.getMessage());
 		}
 		catch (IOException e)
 		{
@@ -183,6 +187,15 @@ default:
 		}
 		finally
 		{
+			try
+			{
+				_connection.close();
+			}
+			catch (IOException e)
+			{
+				LOGGER.debug("Falha ao fechar conexão do gameserver {}.", e, _connectionIp);
+			}
+			
 			// Se o gameserver estava autenticado, marca-o como desconectado.
 			if (isAuthed())
 			{
@@ -249,7 +262,7 @@ default:
 	}
 	
 	/**
-	 * Chamado quando o Game Server solicita uma mudança de nível de acesso para uma conta.
+	 * Chamado quando um jogador solicita uma mudança de nível de acesso para uma conta.
 	 * @param data Os dados do pacote.
 	 */
 	private void onReceiveChangeAccessLevel(byte[] data)
@@ -431,7 +444,7 @@ default:
 	{
 		sendPacket(new LoginServerFail(reason));
 		
-try
+		try
 		{
 			_connection.close();
 		}
@@ -487,7 +500,7 @@ try
 	
 	/**
 	 * Expulsa um jogador do Game Server.
-	 * @param account O nome da conta a ser expulsa.
+	 * @param account O nome da conta a ser expulso.
 	 */
 	public void kickPlayer(String account)
 	{

--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/clientpackets/IncomingPacketFromGameServer.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/clientpackets/IncomingPacketFromGameServer.java
@@ -9,39 +9,34 @@ public abstract class IncomingPacketFromGameServer
 	
 	protected IncomingPacketFromGameServer(byte[] decrypt)
 	{
+		if (decrypt == null || decrypt.length == 0)
+			throw new IllegalArgumentException("Packet payload cannot be null or empty.");
+		
 		_decrypt = decrypt;
 		_off = 1; // skip packet type id
 	}
 	
 	public int readD()
 	{
-		if (_off + 4 > _decrypt.length)
-			throw new IllegalArgumentException("Not enough data to read a D (int).");
-		
+		ensureRemaining(4, "D (int)");
 		return (_decrypt[_off++] & 0xff) | ((_decrypt[_off++] & 0xff) << 8) | ((_decrypt[_off++] & 0xff) << 16) | ((_decrypt[_off++] & 0xff) << 24);
 	}
 	
 	public int readC()
 	{
-		if (_off + 1 > _decrypt.length)
-			throw new IllegalArgumentException("Not enough data to read a C (byte).");
-		
+		ensureRemaining(1, "C (byte)");
 		return _decrypt[_off++] & 0xff;
 	}
 	
 	public int readH()
 	{
-		if (_off + 2 > _decrypt.length)
-			throw new IllegalArgumentException("Not enough data to read an H (short).");
-		
+		ensureRemaining(2, "H (short)");
 		return (_decrypt[_off++] & 0xff) | ((_decrypt[_off++] & 0xff) << 8);
 	}
 	
 	public double readF()
 	{
-		if (_off + 8 > _decrypt.length)
-			throw new IllegalArgumentException("Not enough data to read an F (double).");
-		
+		ensureRemaining(8, "F (double)");
 		final long result = (_decrypt[_off++] & 0xffL) | ((_decrypt[_off++] & 0xffL) << 8) | ((_decrypt[_off++] & 0xffL) << 16) | ((_decrypt[_off++] & 0xffL) << 24) | ((_decrypt[_off++] & 0xffL) << 32) | ((_decrypt[_off++] & 0xffL) << 40) | ((_decrypt[_off++] & 0xffL) << 48) | ((_decrypt[_off++] & 0xffL) << 56);
 		return Double.longBitsToDouble(result);
 	}
@@ -55,41 +50,31 @@ public abstract class IncomingPacketFromGameServer
 		while (end < _decrypt.length - 1 && (_decrypt[end] != 0 || _decrypt[end + 1] != 0))
 		{
 			end += 2;
-			// Add bounds check inside the loop to prevent infinite loop or AIOOBE if string is not null-terminated
 			if (end >= _decrypt.length)
-			{
 				throw new IllegalArgumentException("String not null-terminated or buffer ended prematurely.");
-			}
 		}
 		
-		// Ensure there are at least two bytes for the null terminator after the string content
 		if (end + 2 > _decrypt.length)
-		{
 			throw new IllegalArgumentException("String not properly null-terminated (missing null bytes).");
-		}
 		
-		// Move the offset past the string and the null terminator.
 		_off = end + 2;
-		
-		// Create a string from the bytes between start and end.
 		return new String(_decrypt, start, end - start, StandardCharsets.UTF_16LE);
 	}
 	
 	public final byte[] readB(int length)
 	{
-		if (_off + length > _decrypt.length)
-			throw new IllegalArgumentException("Not enough data to read B (byte array) of length " + length + ".");
+		ensureRemaining(length, "B (byte array)");
 		
-		// Create a new byte array to hold the result.
-		byte[] result = new byte[length];
-		
-		// Use System.arraycopy to efficiently copy the specified number of bytes from the _decrypt array starting at the current offset (_off) into the result array.
+		final byte[] result = new byte[length];
 		System.arraycopy(_decrypt, _off, result, 0, length);
-		
-		// Update the offset (_off) by the length of the data read.
 		_off += length;
-		
-		// Return the byte array containing the copied data.
 		return result;
+	}
+	
+	private void ensureRemaining(int length, String type)
+	{
+		// Subtraction-based validation avoids integer overflow from expressions such as _off + length.
+		if (length < 0 || _off < 0 || _off > _decrypt.length || length > _decrypt.length - _off)
+			throw new IllegalArgumentException("Not enough data to read " + type + " of length " + length + ".");
 	}
 }

--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/gameserverpackets/BlowFishKey.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/gameserverpackets/BlowFishKey.java
@@ -19,8 +19,12 @@ public class BlowFishKey extends IncomingPacketFromGameServer
 	{
 		super(decrypt);
 		
-		int size = readD();
-		byte[] tempKey = readB(size);
+		final int size = readD();
+		final int expectedRsaBlockSize = (privateKey.getModulus().bitLength() + 7) / 8;
+		if (size != expectedRsaBlockSize)
+			throw new IllegalArgumentException("Invalid encrypted Blowfish key size: " + size + ", expected: " + expectedRsaBlockSize + ".");
+		
+		final byte[] tempKey = readB(size);
 		
 		try
 		{
@@ -29,20 +33,25 @@ public class BlowFishKey extends IncomingPacketFromGameServer
 			
 			final byte[] tempDecryptKey = rsaCipher.doFinal(tempKey);
 			
-			// there are nulls before the key we must remove them
+			// There are nulls before the key; remove only the leading padding bytes.
 			int i = 0;
-			int len = tempDecryptKey.length;
+			final int len = tempDecryptKey.length;
 			for (; i < len; i++)
 			{
 				if (tempDecryptKey[i] != 0)
 					break;
 			}
+			
+			if (i == len)
+				throw new IllegalArgumentException("Decrypted Blowfish key is empty.");
+			
 			_key = new byte[len - i];
 			System.arraycopy(tempDecryptKey, i, _key, 0, len - i);
 		}
 		catch (GeneralSecurityException e)
 		{
 			LOGGER.error("Couldn't decrypt blowfish key (RSA)", e);
+			throw new IllegalArgumentException("Couldn't decrypt Blowfish key.", e);
 		}
 	}
 	

--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/gameserverpackets/BlowFishKey.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/gameserverpackets/BlowFishKey.java
@@ -19,6 +19,9 @@ public class BlowFishKey extends IncomingPacketFromGameServer
 	{
 		super(decrypt);
 		
+		if (privateKey == null)
+			throw new IllegalArgumentException("RSA private key cannot be null.");
+		
 		final int size = readD();
 		final int expectedRsaBlockSize = (privateKey.getModulus().bitLength() + 7) / 8;
 		if (size != expectedRsaBlockSize)

--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/gameserverpackets/GameServerAuth.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/network/gameserverpackets/GameServerAuth.java
@@ -4,6 +4,8 @@ import net.sf.l2j.loginserver.network.clientpackets.IncomingPacketFromGameServer
 
 public class GameServerAuth extends IncomingPacketFromGameServer
 {
+	private static final int HEX_ID_LENGTH = 16;
+	
 	private final byte[] _hexId;
 	private final int _desiredId;
 	private final boolean _hostReserved;
@@ -22,7 +24,11 @@ public class GameServerAuth extends IncomingPacketFromGameServer
 		_hostName = readS();
 		_port = readH();
 		_maxPlayers = readD();
-		int size = readD();
+		
+		final int size = readD();
+		if (size != HEX_ID_LENGTH)
+			throw new IllegalArgumentException("Invalid GameServer hexId size: " + size + ", expected: " + HEX_ID_LENGTH + ".");
+		
 		_hexId = readB(size);
 	}
 	


### PR DESCRIPTION
## Resumo

Corrige a vulnerabilidade descrita na issue #20, em que campos de comprimento controlados por um peer não autenticado podiam explorar overflow em `IncomingPacketFromGameServer.readB()` e induzir tentativa de alocação extrema no LoginServer.

## Alterações

- substitui validações baseadas em `_off + length` por checagem por subtração, evitando overflow de `int`;
- rejeita comprimentos negativos antes de qualquer alocação;
- centraliza a validação de bytes restantes em `ensureRemaining()` e reaproveita para `readC`, `readH`, `readD`, `readF` e `readB`;
- valida payload nulo/vazio no construtor do parser;
- `BlowFishKey` exige tamanho exato do bloco RSA com base na chave privada ativa;
- `BlowFishKey` rejeita resultado descriptografado vazio e propaga falha de decriptação como pacote inválido;
- `GameServerAuth` exige `hexId` de 16 bytes, compatível com `LoginServerThread.generateHex(16)` e `GameServerRegister`.

## Segurança

Antes:

```java
if (_off + length > _decrypt.length)
    throw ...;

byte[] result = new byte[length];
```

Um `length = Integer.MAX_VALUE` podia fazer `_off + length` transbordar e chegar à alocação.

Agora:

```java
if (length < 0 || _off < 0 || _off > _decrypt.length || length > _decrypt.length - _off)
    throw ...;
```

O comprimento é rejeitado antes da criação do array e sem soma suscetível a overflow.

## Cenários cobertos pela correção

- `length = Integer.MAX_VALUE`;
- `length = Integer.MIN_VALUE`;
- `length = -1`;
- comprimento maior que os bytes restantes;
- bloco RSA com tamanho diferente do módulo ativo;
- `hexId` com tamanho diferente de 16 bytes;
- payload nulo/vazio.

## Validação realizada

- revisão estática do diff contra `master`;
- confirmação do tamanho legítimo do `hexId`: `LoginServerThread.generateHex(16)` / `GameServerRegister.generateHex(16)`;
- confirmação de que o bloco enviado por `gameserver.network.gameserverpackets.BlowFishKey` é o resultado direto de `Cipher.doFinal()`, portanto seu tamanho deve coincidir com o módulo RSA ativo;
- branch está 3 commits à frente de `master`, alterando somente os 3 arquivos relacionados ao parser/handshake.

Não há suite de testes unitários existente localizada para `IncomingPacketFromGameServer`; não foi introduzida uma nova infraestrutura de testes fora do escopo desta correção. Recomenda-se validar a compilação/CI existente do repositório e adicionar posteriormente testes de fuzzing dedicados ao parser.

## Riscos

Baixo risco funcional. A mudança torna o parser estrito para entradas que já seriam inválidas pelo protocolo.

A validação de `GameServerAuth` assume o formato atual de `hexId` de 16 bytes, que é o tamanho produzido pelos fluxos de registro existentes no repositório.

## Issue relacionada

Closes #20