### PR TITLE
fix(loginserver): cleanup de GameServerThread em todas as saídas

### DIFF
--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/GameServerListener.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/GameServerListener.java
@@ -30,13 +30,20 @@ public class GameServerListener extends FloodProtectedListener
 	@Override
 	public void addClient(Socket s)
 	{
+		GameServerThread gameServer = null;
 		try
 		{
-			// Cria uma nova thread para lidar com a comunicação com o Game Server e a adiciona à lista.
-			_gameServers.add(new GameServerThread(s));
+			// Registra a thread antes de iniciá-la para que o cleanup nunca possa correr antes da inclusão na lista.
+			gameServer = new GameServerThread(s);
+			_gameServers.add(gameServer);
+			gameServer.start();
 		}
-		catch (IOException e)
+		catch (IOException | RuntimeException e)
 		{
+			if (gameServer != null)
+				_gameServers.remove(gameServer);
+			
+			removeFloodProtection(s.getInetAddress().getHostAddress());
 			LOGGER.error("Falha ao inicializar a GameServerThread, fechando conexão.", e);
 			try
 			{

--- a/L2jToren_gameserver/java/net/sf/l2j/loginserver/GameServerThread.java
+++ b/L2jToren_gameserver/java/net/sf/l2j/loginserver/GameServerThread.java
@@ -14,6 +14,7 @@ import java.sql.SQLException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 import net.sf.l2j.commons.logging.CLogger;
 
@@ -47,6 +48,7 @@ public class GameServerThread extends Thread
 	
 	// Conjunto de contas atualmente online neste Game Server.
 	private final Set<String> _accountsOnGameServer = new HashSet<>();
+	private final AtomicBoolean _cleanupDone = new AtomicBoolean();
 	
 	private final Socket _connection;
 	private final String _connectionIp;
@@ -79,23 +81,21 @@ public class GameServerThread extends Thread
 		
 		// Inicializa a criptografia com uma chave estática temporária.
 		_blowfish = new NewCrypt("_;v.]05-31!|+-%xT!^[$\00");
-		
-		start();
 	}
 	
 	@Override
 	public void run()
 	{
-		// Garante que não haverá mais processamento para esta conexão se o servidor for considerado banido.
-		if (IpBanManager.getInstance().isBannedAddress(_connection.getInetAddress()))
-		{
-			LOGGER.info("O gameserver banido com o IP {} tentou se registrar.", _connection.getInetAddress().getHostAddress());
-			forceClose(LoginServerFail.REASON_IP_BANNED);
-			return;
-		}
-		
 		try
 		{
+			// Garante que não haverá mais processamento para esta conexão se o servidor for considerado banido.
+			if (IpBanManager.getInstance().isBannedAddress(_connection.getInetAddress()))
+			{
+				LOGGER.info("O gameserver banido com o IP {} tentou se registrar.", _connection.getInetAddress().getHostAddress());
+				forceClose(LoginServerFail.REASON_IP_BANNED);
+				return;
+			}
+			
 			// Envia o pacote de inicialização com a chave pública RSA.
 			sendPacket(new InitLS(_publicKey.getModulus().toByteArray()));
 			
@@ -187,25 +187,37 @@ public class GameServerThread extends Thread
 		}
 		finally
 		{
-			try
-			{
-				_connection.close();
-			}
-			catch (IOException e)
-			{
-				LOGGER.debug("Falha ao fechar conexão do gameserver {}.", e, _connectionIp);
-			}
-			
-			// Se o gameserver estava autenticado, marca-o como desconectado.
-			if (isAuthed())
-			{
-				_gsi.setDown();
-				LOGGER.info("GameServer [{}] {} foi definido como desconectado.", getServerId(), GameServerManager.getInstance().getServerNames().get(getServerId()));
-			}
-			// Remove o gameserver da lista de listeners.
-			LoginServer.getInstance().getGameServerListener().removeGameServer(this);
-			LoginServer.getInstance().getGameServerListener().removeFloodProtection(_connectionIp);
+			cleanup();
 		}
+	}
+	
+	/**
+	 * Executa o encerramento da conexão uma única vez, independentemente do caminho de saída da thread.
+	 */
+	private void cleanup()
+	{
+		if (!_cleanupDone.compareAndSet(false, true))
+			return;
+		
+		try
+		{
+			_connection.close();
+		}
+		catch (IOException e)
+		{
+			LOGGER.debug("Falha ao fechar conexão do gameserver {}.", e, _connectionIp);
+		}
+		
+		// Se o gameserver estava autenticado, marca-o como desconectado.
+		if (isAuthed())
+		{
+			_gsi.setDown();
+			LOGGER.info("GameServer [{}] {} foi definido como desconectado.", getServerId(), GameServerManager.getInstance().getServerNames().get(getServerId()));
+		}
+		
+		final GameServerListener listener = LoginServer.getInstance().getGameServerListener();
+		listener.removeGameServer(this);
+		listener.removeFloodProtection(_connectionIp);
 	}
 	
 	/**


### PR DESCRIPTION
## Resumo

Corrige o lifecycle de conexões de GameServer descrito na issue #21.

### Alterações
- remove o `start()` do construtor de `GameServerThread`;
- registra a thread em `_gameServers` antes de iniciá-la;
- move a validação de IP banido para dentro do `try/finally`;
- centraliza o encerramento em `cleanup()` protegido por `AtomicBoolean`, evitando execução duplicada;
- garante remoção da thread e do registro de flood em toda saída de `run()`;
- limpa lista/flood também quando a criação ou o `start()` da thread falham.

## Causa raiz

A verificação de IP banido retornava antes do `finally`, e `GameServerThread` era iniciada dentro do próprio construtor antes de `GameServerListener` conseguir registrá-la. Isso permitia referências órfãs em `_gameServers` e contadores de flood inconsistentes.

## Validação

- diff revisado contra `master`;
- branch está 2 commits à frente e 0 atrás de `master`;
- o projeto não possui suíte JUnit identificável para esse componente; a validação automatizada disponível será conferida pelos checks do GitHub após a abertura da PR.

Closes #21